### PR TITLE
Fixed animation controller dispose

### DIFF
--- a/lib/src/day_night_themed_switcher.dart
+++ b/lib/src/day_night_themed_switcher.dart
@@ -197,4 +197,10 @@ class _DayNightSwitchState extends State<DayNightSwitch>
       ),
     );
   }
+
+  @override
+  void dispose() {
+    animationController.dispose();
+    super.dispose();
+  }
 }


### PR DESCRIPTION
The animation controller was not being disposed in `day_night_themed_switcher.dart` causing these exceptions,
```
════════ Exception caught by widgets library ═══════════════════════════════════
The following assertion was thrown while finalizing the widget tree:
_DayNightSwitchState#6394f(ticker active) was disposed with an active Ticker.
_DayNightSwitchState created a Ticker via its SingleTickerProviderStateMixin, but at the time dispose() was called on the mixin, that Ticker was still active. The Ticker must be disposed before calling super.dispose().
Tickers used by AnimationControllers should be disposed by calling dispose() on the AnimationController itself. Otherwise, the ticker will leak.
The offending ticker was: Ticker(created by _DayNightSwitchState#6394f)
```

So I added the dispose function, fixing this issue